### PR TITLE
Fix spacing when forced into a list

### DIFF
--- a/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
@@ -275,9 +275,8 @@ class ExperimentPlanner(object):
                                                              999999)
         num_stages = len(pool_op_kernel_sizes)
 
-        spacing = list(spacing)
-        if len(spacing) == 2:
-            spacing = [None] + spacing
+        if spacing.size == 2:
+            spacing = np.insert(spacing, 0, None)
 
         norm = get_matching_instancenorm(unet_conv_op)
         architecture_kwargs = {


### PR DESCRIPTION
This causes the script to break as `lowres_spacing` is used as an array later

https://github.com/TaWald/nnUNet/blob/5065433cc3c26615a23c79517e8fabdf004f647c/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py#L458