### PR TITLE
Improve the planning and preprocessing pipeline for fine-tuning nnssl pre-trained checkpoints

### DIFF
--- a/nnunetv2/experiment_planning/plan_and_preprocess_scratch.py
+++ b/nnunetv2/experiment_planning/plan_and_preprocess_scratch.py
@@ -1,0 +1,179 @@
+import argparse
+
+from batchgenerators.utilities.file_and_folder_operations import isfile, join, save_json
+
+from nnunetv2.paths import nnUNet_preprocessed
+from nnunetv2.preprocessing.preprocessors.default_preprocessor import (
+    DefaultPreprocessor,
+)
+from nnunetv2.utilities.dataset_name_id_conversion import convert_id_to_dataset_name
+from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
+
+
+def plan_and_preprocess_scratch(
+    dataset_id: int,
+    network_name: str,
+    override_spacing: tuple[float, float, float] | None,
+    override_normalization: str | None,
+    override_patchsize: tuple[int, int, int] | None,
+    override_batchsize: int | None,
+    no_pp: bool,
+    num_processes: int,
+    verbose: bool,
+):
+    dataset_name = convert_id_to_dataset_name(dataset_id)
+    print(f"Planning scratch for: {dataset_name}")
+    # Check if nnUNetPLans exists or ResEncL/M/S or whatever
+    potential_plans = ["nnUNetPlans.json"] + [f"nnUNetResEncUNet{k}Plans.json" for k in "_M_L_XL".split("_")]
+    existing_plans = [p for p in potential_plans if isfile(join(nnUNet_preprocessed, dataset_name, p))]
+    assert len(existing_plans) > 0, f"Could not find any plans file for dataset {dataset_name}. Please plan the dataset normally first to do preprocessing from pretrained. FYI, we check for {potential_plans}"
+    plans_file = join(nnUNet_preprocessed, dataset_name, existing_plans[0])
+    print(f"Using auto-detected default plans file: {plans_file}")
+    plans_manager = PlansManager(plans_file)
+    config_manager = plans_manager.get_configuration("3d_fullres")  # Just focus on 3d_fullres
+
+    # Override spacing
+    if override_spacing is not None:
+        config_manager.configuration["spacing"] = override_spacing
+
+    # Override normalization schemes
+    if override_normalization is not None:
+        short_norm_name = "Z" if override_normalization == "ZScoreNormalization" else override_normalization.replace("Normalization", "")
+        new_normalization_schemes = [override_normalization for _ in config_manager.configuration["normalization_schemes"]]
+        config_manager.configuration["normalization_schemes"] = new_normalization_schemes
+
+    # Override patch size
+    if override_patchsize is not None:
+        config_manager.configuration["patch_size"] = override_patchsize
+
+    # Override batch size
+    if override_batchsize is not None:
+        config_manager.configuration["batch_size"] = override_batchsize
+
+    # Set data identifier
+    spacing_format = "Spacing_{}_{}_{}".format(*[f"{x:.2f}" if x is not None else "None" for x in config_manager.configuration["spacing"]])
+    norm_scheme_format = "Norm_" + "_".join([short_norm_name for _ in new_normalization_schemes])
+    data_identifier = spacing_format + "__" + norm_scheme_format  # Data identity only controlled by spacing and normalization
+    config_manager.configuration["data_identifier"] = data_identifier
+
+    # Set network architecture
+    architecture = {}
+    architecture["_kw_requires_import"] = None
+    architecture["arch_kwargs"] = None
+    architecture["network_class_name"] = network_name
+    config_manager.configuration["architecture"] = architecture
+
+    # Set an empty pretrain info to indicate training from scratch
+    plans_manager.plans["pretrain_info"] = {}
+
+    # Needs to be overriden (see below the code before preprocessor.run())
+    config_manager.configuration["preprocessor_name"] = "DefaultPreprocessor"
+
+    plans_manager.plans["configurations"] = {"3d_fullres": config_manager.configuration}
+
+    # Save plans json
+    patch_size_format = "PS_{}_{}_{}".format(*[f"{x}" if x is not None else "None" for x in config_manager.configuration["patch_size"]])
+    batch_size_format = "BS_{}".format(config_manager.configuration["batch_size"])
+    plans_name = f"scratchPlans__{network_name}__{data_identifier}__{patch_size_format}__{batch_size_format}"
+    plans_manager.plans["plans_name"] = plans_name
+    save_json(plans_manager.plans, join(nnUNet_preprocessed, dataset_name, plans_name + ".json"))
+
+    if not no_pp:
+        print(f"Preprocessing scratch for: {dataset_name}")
+        preprocessor: DefaultPreprocessor = config_manager.preprocessor_class(verbose=verbose)
+        preprocessor.run(dataset_id, "3d_fullres", plans_name, num_processes=num_processes, overwrite_existing=False)
+
+
+def plan_and_preprocess_scratch_entrypoint():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--dataset_id",
+        type=int,
+        required=True,
+        help="[REQUIRED] Dataset ID.",
+    )
+    parser.add_argument(
+        "-nn",
+        "--network_name",
+        type=str,
+        required=True,
+        help="[REQUIRED] Name of the network architecture, e.g., ResEncL, PrimusM.",
+    )
+    parser.add_argument(
+        "-os",
+        "--override_spacing",
+        nargs="+",
+        type=float,
+        required=False,
+        help="[OPTIONAL] Override spacing, e.g., 1.0 1.0 1.0",
+    )
+    parser.add_argument(
+        "-on",
+        "--override_normalization",
+        type=str,
+        required=False,
+        help="[OPTIONAL] Override normalization scheme, e.g., ZScoreNormalization",
+    )
+    parser.add_argument(
+        "-op",
+        "--override_patchsize",
+        nargs="+",
+        type=int,
+        required=False,
+        help="[OPTIONAL] Override patch size, e.g., 128 128 128",
+    )
+    parser.add_argument(
+        "-ob",
+        "--override_batchsize",
+        type=int,
+        required=False,
+        help="[OPTIONAL] Override batch size, e.g., 2",
+    )
+    parser.add_argument(
+        "--no_pp",
+        action="store_true",
+        required=False,
+        help="[OPTIONAL] Only do planning but no preprocessing.",
+    )
+    parser.add_argument(
+        "-np",
+        "--num_processes",
+        default=4,
+        type=int,
+        required=False,
+        help="[OPTIONAL] Number of processes to use for preprocessing. Default: 4",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        required=False,
+        help="[OPTIONAL] Set this to print a lot of stuff. Useful for debugging. Will disable progress bar!",
+    )
+    args = parser.parse_args()
+
+    dataset_id: int = args.dataset_id
+    network_name: str = args.network_name
+    override_spacing: tuple[float, float, float] | None = args.override_spacing
+    override_normalization: str | None = args.override_normalization
+    override_patchsize: tuple[int, int, int] | None = args.override_patchsize
+    override_batchsize: int | None = args.override_batchsize
+    no_pp: bool = args.no_pp
+    num_processes: int = args.num_processes
+    verbose: bool = args.verbose
+
+    plan_and_preprocess_scratch(
+        dataset_id=dataset_id,
+        network_name=network_name,
+        override_spacing=override_spacing,
+        override_normalization=override_normalization,
+        override_patchsize=override_patchsize,
+        override_batchsize=override_batchsize,
+        no_pp=no_pp,
+        num_processes=num_processes,
+        verbose=verbose,
+    )
+
+
+if __name__ == "__main__":
+    plan_and_preprocess_scratch_entrypoint()

--- a/nnunetv2/experiment_planning/plan_nnssl.py
+++ b/nnunetv2/experiment_planning/plan_nnssl.py
@@ -1,0 +1,156 @@
+import argparse
+import os
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+from batchgenerators.utilities.file_and_folder_operations import join, save_json
+from huggingface_hub import hf_hub_download
+
+from nnunetv2.paths import nnUNet_preprocessed
+from nnunetv2.utilities.dataset_name_id_conversion import convert_id_to_dataset_name
+from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
+
+
+def plan_nnssl(
+    dataset_id: int,
+    pt_name: str,
+    pt_ckpt_path: str,
+    scratch_identifier: str | None,
+):
+    dataset_name = convert_id_to_dataset_name(dataset_id)
+    print(f"Planning nnssl for: {dataset_name}")
+    # Adapt from the previous train-from-scratch plans
+    if scratch_identifier is None:
+        # Automatically search for the first scratchPlans__xxxx.json
+        existing_scratch_plans_file = [f for f in os.listdir(join(nnUNet_preprocessed, dataset_name)) if f.startswith("scratchPlans__") and f.endswith(".json")]
+        scratch_identifier = existing_scratch_plans_file[0].replace(".json", "")
+        scratch_plans_file = join(nnUNet_preprocessed, dataset_name, scratch_identifier + ".json")
+        print(f"Using auto-detected scratch plans file: {scratch_plans_file}")
+    else:
+        scratch_plans_file = join(nnUNet_preprocessed, dataset_name, scratch_identifier + ".json")
+    scratch_plans_manager = PlansManager(scratch_plans_file)
+
+    # -------------------------------- Adapt plan -------------------------------- #
+    loaded_pt_ckpt = torch.load(pt_ckpt_path, weights_only=True, map_location="cpu")
+    loaded_adapt_plan = loaded_pt_ckpt["nnssl_adaptation_plan"]
+    adapted_plans_manager = deepcopy(scratch_plans_manager)
+    adapted_config_manager = adapted_plans_manager.get_configuration("3d_fullres")
+    _key = list(loaded_adapt_plan["pretrain_plan"]["configurations"].keys())[0]  # For pt_used_patchsize
+    pretrain_info = {
+        "checkpoint_path": pt_ckpt_path,
+        "checkpoint_name": pt_name,
+        "key_to_encoder": loaded_adapt_plan["key_to_encoder"],
+        "key_to_stem": loaded_adapt_plan["key_to_stem"],
+        "keys_to_in_proj": loaded_adapt_plan["keys_to_in_proj"],
+        "key_to_lpe": loaded_adapt_plan["key_to_lpe"],
+        "pt_num_in_channels": loaded_adapt_plan["pretrain_num_input_channels"],
+        "pt_used_patchsize": loaded_adapt_plan["pretrain_plan"]["configurations"][_key]["patch_size"],
+        "citations": loaded_pt_ckpt["citations"] if "citations" in loaded_pt_ckpt else [],
+    }
+    # Save important info for pretraining
+    adapted_plans_manager.plans["pretrain_info"] = pretrain_info
+
+    # Set network architecture
+    architecture: dict = loaded_adapt_plan["architecture_plans"]
+    architecture["_kw_requires_import"] = architecture.pop("arch_kwargs_requiring_import")
+    architecture["network_class_name"] = architecture.pop("arch_class_name")
+    adapted_config_manager.configuration["architecture"] = architecture
+
+    adapted_plans_manager.plans["configurations"] = {"3d_fullres": adapted_config_manager.configuration}
+
+    # Save plans json
+    plans_name = f"ptPlans__{pt_name}__{scratch_identifier.replace("scratchPlans__", "")}"
+    adapted_plans_manager.plans["plans_name"] = plans_name
+    save_json(adapted_plans_manager.plans, join(nnUNet_preprocessed, dataset_name, plans_name + ".json"))
+
+
+def maybe_download_pretrained_weights(pretrained_checkpoint_path: str):
+    """
+    Check if the pretrained checkpoint path points to a hugging face directory.
+    If it does, check the repository has an adaptation_plan.json file indicating compatibility with nnssl.
+    If it exists, download the checkpoint and store it. Then replace the local path with the URL and continue as usual.
+    :param pretrained_checkpoint_path: Path or URL to the pretrained checkpoint.
+    """
+
+    # Check if the path is a Hugging Face repository URL
+    if pretrained_checkpoint_path.startswith("https://huggingface.co/"):
+        assert "nnssl_pretrained_models" in os.environ, "To allow auto-downloading weights you need to set the environment variable 'nnssl_pretrained_models' to the path where you want to store the pretrained models."
+        local_dir = os.environ["nnssl_pretrained_models"]
+        repo_id = pretrained_checkpoint_path.split("https://huggingface.co/")[-1].strip("/")
+
+        final_path = os.path.join(local_dir, repo_id.replace("/", "_"))
+        if not os.path.exists(final_path):
+            os.makedirs(final_path, exist_ok=True)
+        # Check if the repository contains the adaptation_plan.json file
+        try:
+            _ = hf_hub_download(repo_id=repo_id, filename="adaptation_plan.json", local_dir=final_path)
+        except Exception as e:
+            raise ValueError(f"The repository {repo_id} does not contain an adaptation_plan.json file.\n" "This indicates that the checkpoint is not compatible with this fine-tuning workflow." f"Error: {e}")
+
+        # Download the checkpoint file
+        try:
+            checkpoint_path = hf_hub_download(repo_id=repo_id, filename="checkpoint_final.pth", local_dir=final_path)
+            # For download tracking purposes
+            _ = hf_hub_download(repo_id=repo_id, filename="config.json", local_dir=final_path)
+        except Exception as e:
+            raise ValueError(f"Failed to download the checkpoint file from the repository {repo_id}. " f"Error: {e}")
+
+        # Replace the local path with the downloaded checkpoint path
+        pretrained_checkpoint_path = checkpoint_path
+
+    # Verify the local path exists
+    if not Path(pretrained_checkpoint_path).is_file():
+        raise FileNotFoundError(f"The pretrained checkpoint path {pretrained_checkpoint_path} does not exist.")
+    return pretrained_checkpoint_path
+
+
+def plan_nnssl_entrypoint():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--dataset_id",
+        type=int,
+        required=True,
+        help="[REQUIRED] Dataset ID.",
+    )
+    parser.add_argument(
+        "-ptn",
+        "--pretrain_name",
+        type=str,
+        required=True,
+        help="[REQUIRED] !Unique! name of the pretraining. Used to name the plans file." "Could look something like this 'CNN_MAE_XY_Dataset_Z'.",
+    )
+    parser.add_argument(
+        "-pc",
+        "--pretrained_checkpoint_path",
+        type=str,
+        required=True,
+        help="[REQUIRED] Path to the pretrained ckpt`<CKPT>.pth` of a pre-training done with nnssl.",
+    )
+    parser.add_argument(
+        "-si",
+        "--scratch_identifier",
+        type=str,
+        required=False,
+        help="[OPTIONAL] Base name of the train-from-scratch plans json. If not provided, will automatically search for the first scratchPlans__xxxx.json",
+    )
+    args = parser.parse_args()
+
+    dataset_id: int = args.dataset_id
+    pretrain_name: str = args.pretrain_name
+    pretrained_checkpoint_path: str = args.pretrained_checkpoint_path
+    scratch_identifier: str | None = args.scratch_identifier
+
+    pretrained_checkpoint_path: str = maybe_download_pretrained_weights(pretrained_checkpoint_path)
+
+    plan_nnssl(
+        dataset_id=dataset_id,
+        pt_name=pretrain_name,
+        pt_ckpt_path=pretrained_checkpoint_path,
+        scratch_identifier=scratch_identifier,
+    )
+
+
+if __name__ == "__main__":
+    plan_nnssl_entrypoint()


### PR DESCRIPTION
This commit tries to break down into two steps the plan-preprocess pipeline defined in [like_nnssl.py](https://github.com/TaWald/nnUNet/blob/nnssl_finetuning_inclusion/nnunetv2/experiment_planning/like_nnssl.py).

### Step 1
In [plan_and_preprocess_scratch.py](https://github.com/TaWald/nnUNet/compare/nnssl_finetuning_inclusion...jsadu826:pr3?expand=1#diff-05d871ad6ce11523e959806cf64c9540bb3c479e46dfe3df8cec414c7282a3dd), users can override spacing, normalization scheme, patch size, and batch size in order to match the nnssl settings and a train-from-scratch plan json is generated. In this way, we decouple train-from-scratch and train-pretrained. However, for simplicity we did not modify the trainer script, so users still need to set the `--from_scratch` flag when training downstreams from scratch. Then, data is be preprocessed as normal, or users can disable preprocessing by setting the `--no_pp` flag.

### Step 2

[plan_nnssl.py](https://github.com/TaWald/nnUNet/compare/nnssl_finetuning_inclusion...jsadu826:pr3?expand=1#diff-b3238d760280b831e83af8404eef03612c78e9c162979dc64a0a4ea98bc00966) adapts a train-pretrained plan from the train-from-scratch plan rather than the nnssl plan. This step only generates plan json and does not touch upon data.

### Usage

Users can seamlessly replace
```
nnUNetv2_preprocess_like_nnssl \
    -d <dataset_identifier> \
    -n <UniqueNameOfTraining> \
    -pc <Path/to/the/pretrained/checkpoint.pth> \
    -am "like_pretrained"
```
with
```
python -m nnunetv2.experiment_planning.plan_and_preprocess_scratch \
    -d <dataset_identifier> \
    -nn ResEncL \
    -os 1 1 1 \
    -on ZScoreNormalization \
    -op 160 160 160 \
    -ob 2 \
    -np 8
````
and
```
python -m nnunetv2.experiment_planning.plan_nnssl \
    -d <dataset_identifier> \
    -ptn <UniqueNameOfTraining> \
    -pc <Path/to/the/pretrained/checkpoint.pth>
````
The final plan-preprocessed folder structure is something like:
<img width="587" height="162" alt="image" src="https://github.com/user-attachments/assets/e66df52f-d8a8-470d-8a34-3413572773fb" />

