### PR TITLE
Fix: lowres array handling in experiment planner

### DIFF
--- a/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
@@ -448,6 +448,7 @@ class ExperimentPlanner(object):
 
             plan_3d_lowres = None
             lowres_spacing = deepcopy(plan_3d_fullres['spacing'])
+            lowres_spacing = np.array(lowres_spacing)  # Ensure it's a NumPy array
 
             spacing_increase_factor = 1.03  # used to be 1.01 but that is slow with new GPU memory estimation!
             while num_voxels_in_patch / median_num_voxels < self.lowres_creation_threshold:
@@ -455,7 +456,7 @@ class ExperimentPlanner(object):
                 # is/are similar (factor 2) to the other ax(i/e)s.
                 max_spacing = max(lowres_spacing)
                 if np.any((max_spacing / lowres_spacing) > 2):
-                    lowres_spacing = np.array(lowres_spacing)  # Ensure it's a NumPy array
+                    #lowres_spacing = np.array(lowres_spacing)  # Ensure it's a NumPy array
                     max_spacing = np.max(lowres_spacing)
                     mask = (max_spacing / lowres_spacing) > 2
                     lowres_spacing[mask] *= spacing_increase_factor

--- a/nnunetv2/training/nnUNetTrainer/pretraining/pretrainedTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/pretraining/pretrainedTrainer.py
@@ -599,6 +599,54 @@ class PretrainedTrainer_150ep(PretrainedTrainer):
         self.warmup_duration_whole_net = 15 # lin increase whole network
         self.num_epochs = 150
 
+class PretrainedTrainer_50ep(PretrainedTrainer):
+
+    def __init__(
+            self,
+            plans: dict,
+            configuration: str,
+            fold: int,
+            dataset_json: dict,
+            use_pretrained_weights: bool = True,
+            device: torch.device = torch.device("cuda"),
+    ):
+        super().__init__(plans, configuration, fold, dataset_json, use_pretrained_weights, device)
+        # Can be overriden to train same architecture from scratch.
+        self.warmup_duration_whole_net = 5 # lin increase whole network
+        self.num_epochs = 50
+
+class PretrainedTrainer_15ep(PretrainedTrainer):
+
+    def __init__(
+            self,
+            plans: dict,
+            configuration: str,
+            fold: int,
+            dataset_json: dict,
+            use_pretrained_weights: bool = True,
+            device: torch.device = torch.device("cuda"),
+    ):
+        super().__init__(plans, configuration, fold, dataset_json, use_pretrained_weights, device)
+        # Can be overriden to train same architecture from scratch.
+        self.warmup_duration_whole_net = 1 # lin increase whole network
+        self.num_epochs = 15
+
+class PretrainedTrainer_5ep(PretrainedTrainer):
+
+    def __init__(
+            self,
+            plans: dict,
+            configuration: str,
+            fold: int,
+            dataset_json: dict,
+            use_pretrained_weights: bool = True,
+            device: torch.device = torch.device("cuda"),
+    ):
+        super().__init__(plans, configuration, fold, dataset_json, use_pretrained_weights, device)
+        # Can be overriden to train same architecture from scratch.
+        self.warmup_duration_whole_net = 1 # lin increase whole network
+        self.num_epochs = 5
+
 class PretrainedTrainer_Primus_150ep(PretrainedTrainer_Primus):
 
     def __init__(


### PR DESCRIPTION
Fixes experiment planning failure caused by `lowres_spacing` being a list 
instead of numpy array. Added explicit `np.array()` conversion.

Tested with planning workflow - now works correctly.