### PR TITLE
Fix: Aparently inference for some models require to specify the patch…

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -105,6 +105,7 @@ class nnUNetPredictor(object):
             configuration_manager.network_arch_class_name,
             configuration_manager.network_arch_init_kwargs,
             configuration_manager.network_arch_init_kwargs_req_import,
+            configuration_manager.patch_size,
             num_input_channels,
             plans_manager.get_label_manager(dataset_json).num_segmentation_heads,
             enable_deep_supervision=False


### PR DESCRIPTION
Fixes inference failure for models requiring explicit patch size specification.
Some model configurations need patch size to be passed during prediction - 
this was missing and causing inference to fail.
